### PR TITLE
Fix: 画面の整備

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ShinobueFumen</title>
+    <title><%= t('defaults.service_name') %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,27 +1,17 @@
 <header>
   <nav class='navbar navbar-expand-lg navigation navbar-light bg-white'>
-    <%= link_to root_path, class: 'navbar-brand' do %>
-      <%= image_tag 'logo.png' %>
-    <% end %>
-
-    <%= form_with(url: new_sheet_path, method: :get) do |form| %>
-      <div class="row">
-        <div class="col">
-          <%= form.select :level, options_for_select(@level, selected: Sheet::DEFAULT_LEVEL), {}, { class: 'form-control' } %>
-        </div>
-        <div class="col">
-          <%= form.submit t('defaults.make_music'), class: 'btn btn-primary btn-lg' %>
-        </div>
-      </div>
-    <% end %>
+    <%= render 'shared/common' %>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav ml-auto main-nav align-items-center">
+      <ul class="navbar-nav ms-auto main-nav align-items-center">
         <li class="nav-item">
-          <%= link_to 'ログイン', login_path ,class: 'nav-link' %>
+          <%= link_to t('defaults.login'), login_path ,class: 'nav-link' %>
+        </li>
+        <li class="nav-item">
+          <%= link_to t('defaults.user_register'), new_user_path ,class: 'nav-link' %>
         </li>
       </ul>
     </div>

--- a/app/views/shared/_common.html.erb
+++ b/app/views/shared/_common.html.erb
@@ -1,0 +1,13 @@
+    <%= link_to root_path, class: 'navbar-brand' do %>
+      <%= image_tag 'logo.png' %>
+    <% end %>
+    <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+      <%= form_with(url: new_sheet_path, method: :get) do |form| %>
+        <li class="nav-item">
+          <%= form.submit t('defaults.make_music'), class: 'btn btn-primary btn-lg' %>
+        </li>
+        <li class="nav-item">
+          <%= form.select :level, options_for_select(@level, selected: Sheet::DEFAULT_LEVEL), {}, { class: 'form-control' } %>
+        </li>
+      <% end %>
+    </ul>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,28 +1,19 @@
 <header>
   <nav class='navbar navbar-expand-lg navigation navbar-light bg-white'>
-    <%= link_to root_path, class: 'navbar-brand' do %>
-      <%= image_tag 'logo.png' %>
-    <% end %>
-
-    <%= form_with(url: new_sheet_path, method: :get) do |form| %>
-      <div class="row">
-        <div class="col">
-          <%= form.select :level, options_for_select(@level, selected: Sheet::DEFAULT_LEVEL), {}, { class: 'form-control' } %>
-        </div>
-        <div class="col">
-          <%= form.submit t('defaults.make_music'), class: 'btn btn-primary btn-lg' %>
-        </div>
-      </div>
-    <% end %>
+    <%= render 'shared/common' %>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav ml-auto main-nav align-items-center">
-        <li class="nav-item">
-          <%= button_to 'ログアウト', logout_path, method: :delete, class: "btn btn-link" %>
+      <ul class="navbar-nav ms-auto main-nav align-items-center">
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <%= current_user.name %>
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+            <%= button_to t('defaults.logout'), logout_path, method: :delete, class: "btn btn-link nav-link" %>
+          </ul>
         </li>
       </ul>
     </div>

--- a/app/views/sheets/_sheet.html.erb
+++ b/app/views/sheets/_sheet.html.erb
@@ -4,7 +4,7 @@
 <input type="hidden" id="sheet" value="<%= sheet.comma_joined_mml %>">
 
 <div id="note">
-  <table class="table table-bordered">
+  <table class="table table-bordered text-nowrap">
     <thead>
       <tr class="table-info">
         <th style="width: 12.5%" scope="col" colspan="2">1</th>

--- a/app/views/sheets/index.html.erb
+++ b/app/views/sheets/index.html.erb
@@ -1,12 +1,27 @@
 <div class="container">
-  <h1>譜面一覧</h1>
+    <div class="fs-5 shadow p-3 mb-5 bg-body rounded">
+      <p>「曲を作成する」を押すと、指定レベルの練習曲を自動作成します。</p>
+      <ul class="fs-6">
+        <li>レベル1：呂音（低音域）のみ</li>
+        <li>レベル2：呂音（低音域）と甲音（高音域）</li>
+        <li>レベル3：メリ音（半音）「七×」「７×」</li>
+        <li>レベル4：メリ音（半音）「三×」「３×」「七×」「７×」</li>
+    </div>
+    <table class="table">
+      <thead class="table-light">
+        <tr>
+          <th scope="col"><%= t('.etude_list') %></th>
+          <th scope="col"><%= t('.user_name') %></th>
+        </tr>
+      </thead>
 
-  <div id="sheets">
-    <% @sheets.each do |sheet| %>
-      <p>
-        <%= link_to sheet.title, sheet %>
-        <%= sheet.user.name %>
-      </p>
-    <% end %>
-  </div>
+      <tbody>
+        <% @sheets.each do |sheet| %>
+          <tr>
+            <td><%= link_to sheet.title, sheet %></td>
+            <td><%= sheet.user.name %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
 </div>

--- a/app/views/sheets/new.html.erb
+++ b/app/views/sheets/new.html.erb
@@ -1,18 +1,14 @@
 <div class="container">
-  <div class="row">
-    <div class="col-md-12">
-      <%= render @sheet %>
-      <% if logged_in? %>
-        <%= form_with model: @sheet, local: true do |f| %>
-          <div class="form-group">
-            <%= f.label :title %>
-            <%= f.text_field :title, class: 'form-control' %>
-          </div>
-          <%= f.hidden_field :level, value: @sheet.level %>
-          <%= f.hidden_field :comma_joined_mml, value: @sheet.comma_joined_mml %>
-          <%= f.submit class: 'btn btn-outline-primary' %>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
+  <%= render @sheet %>
+  <% if logged_in? %>
+    <%= form_with model: @sheet, local: true do |f| %>
+      <div class="form-group">
+        <%= f.label :title %>
+        <%= f.text_field :title, class: 'form-control' %>
+      </div>
+      <%= f.hidden_field :level, value: @sheet.level %>
+      <%= f.hidden_field :comma_joined_mml, value: @sheet.comma_joined_mml %>
+      <%= f.submit class: 'btn btn-outline-primary' %>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/sheets/show.html.erb
+++ b/app/views/sheets/show.html.erb
@@ -1,21 +1,17 @@
 <div class="container">
-  <div class="row">
-    <div class="col-md-12">
-      <%= render @sheet %>
-      <h5>投稿者：<%= @sheet.user.name %></h5>
-      <% if logged_in? && current_user.own?(@sheet) %>
-        <%= form_with model: @sheet, local: true do |f| %>
-          <div class="form-group">
-            <%= f.label :title %>
-            <%= f.text_field :title, class: 'form-control' %>
-          </div>
-          <%= f.submit class: 'btn btn-outline-primary' %>
-        <% end %>
-        <% msg = t('defaults.message.delete_confirm') %>
-        <%= button_to t('defaults.delete'), sheet_path(@sheet), method: :delete, class: "btn btn-outline-danger btn-sm", form: { onSubmit: "return check('#{msg}')" } %>
-      <% end %>
-    </div>
-  </div>
+  <%= render @sheet %>
+  <p class="fst-italic fs-5"><%= @sheet.user.name %></p>
+  <% if logged_in? && current_user.own?(@sheet) %>
+    <%= form_with model: @sheet, local: true do |f| %>
+      <div class="form-group">
+        <%= f.label :title %>
+        <%= f.text_field :title, class: 'form-control' %>
+      </div>
+      <%= f.submit class: 'btn btn-outline-primary' %>
+    <% end %>
+    <% msg = t('defaults.message.delete_confirm') %>
+    <%= button_to t('defaults.delete'), sheet_path(@sheet), method: :delete, class: "btn btn-outline-danger btn-sm", form: { onSubmit: "return check('#{msg}')" } %>
+  <% end %>
 </div>
 
 <script>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1>ログイン</h1>
+      <h1><%= t '.title' %></h1>
       <%= form_with url: login_path, local: true do |f| %>
         <div class="form-group">
           <%= f.label :email %>
@@ -12,11 +12,11 @@
           <%= f.password_field :password, class: 'form-control' %>
         </div>
         <div class="actions">
-          <%= f.submit 'ログイン', class: 'btn btn-primary' %>
+          <%= f.submit t('defaults.login'), class: 'btn btn-primary' %>
         </div>
       <% end %>
       <div class='text-center'>
-        <%= link_to '登録ページへ', new_user_path %>
+        <%= link_to (t '.to_register_page'), new_user_path %>
       </div>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1>ユーザー登録</h1>
+      <h1><%= t '.title' %></h1>
       <%= form_with model: @user, local: true do |f| %>
         <div class="form-group">
           <%= f.label :name %>
@@ -19,10 +19,10 @@
           <%= f.label :password_confirmation %>
           <%= f.password_field :password_confirmation, class: 'form-control' %>
         </div>
-        <%= f.submit '登録', class: 'btn btn-primary' %>
+        <%= f.submit (t 'defaults.register'), class: 'btn btn-primary' %>
       <% end %>
       <div class='text-center'>
-        <%= link_to 'ログインページへ', login_path %>
+        <%= link_to t('.to_login_page'), login_path %>
       </div>
     </div>
   </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -2,5 +2,5 @@
 
 pin "application", preload: true
 pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.2.3/dist/js/bootstrap.esm.js"
-pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.7/lib/index.js"
+pin "@popperjs/core", to: "https://unpkg.com/@popperjs/core@2.11.7/dist/esm/index.js"
 pin_all_from 'app/javascript/custom', under: 'custom'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,6 +1,8 @@
 ja:
   defaults:
+    service_name: '篠笛練習曲自動作成'
     login: 'ログイン'
+    user_register: 'ユーザー登録'
     register: '登録'
     logout: 'ログアウト'
     post: '投稿'
@@ -44,6 +46,8 @@ ja:
     index:
       title: '譜面一覧'
       no_result: '譜面がありません'
+      etude_list: '登録練習曲一覧'
+      user_name: 'ユーザー名'
     show:
       title: '譜面詳細'
     create:


### PR DESCRIPTION
## 概要

画面の整備 #10
- 登録練習曲一覧を表で表示するように修正
- アプリの使い方を記載
- ログイン中はユーザー名を表示するように修正
- ログアウトはドロップダウンメニューから行うように修正
- タイトルはサービス名になるように修正
- 譜面について、表示枠が狭くなっても、改行しないように修正

## コメント

PCで譜面を表示したときは、各拍の枠幅は固定になるが、
スマホなど幅が狭い画面で見ると、枠幅が可変になる。
小さい画面では、固定より可変の方が見やすいと思えるため、現状はこのままとする。