### PR TITLE
Fix: 練習曲作成処理の見直し

### DIFF
--- a/app/javascript/custom/play.js
+++ b/app/javascript/custom/play.js
@@ -1,6 +1,5 @@
 let context;
 let timerID = [];
-const tempo = 80;
 const yubiuchi = 0.05; // 指打ちの時間(秒)
 const volume = 0.2;
 
@@ -29,12 +28,11 @@ const notes = {
   "O5g":  792,     // ６
   "O5a-": 836,     // ７x
   "O5a":  888,     // ７
-  "O5b-": 939,     // ８x(未使用)
-  "O5b":  997,     // ８(大甲)
-  "O6c":  528 * 2, // ２(大甲)
-  "O6d":  594 * 2, // ３(大甲)
-  "O6e-": 627 * 2, // ４(大甲)
-  "O6f":  704 * 2, // ５(大甲)
+  "O5b-": 939,     // ８(大甲)
+  "O6c":  528 * 2, // ２(大甲)(未使用)
+  "O6d":  594 * 2, // ３(大甲)(未使用)
+  "O6e-": 627 * 2, // ４(大甲)(未使用)
+  "O6f":  704 * 2, // ５(大甲)(未使用)
   "O6g":  792 * 2, // (未使用)
 };
 const uchi_notes = {
@@ -62,12 +60,11 @@ const uchi_notes = {
   "O5g":  888,     // ６
   "O5a-": 888,     // ７x
   "O5a":  792,     // ７
-  "O5b-": 888,     // ８x(未使用)
-  "O5b":  888,     // ８(大甲)
-  "O6c":  0,       // ２(大甲)
-  "O6d":  0,       // ３(大甲)
-  "O6e-": 0,       // ４(大甲)
-  "O6f":  0,       // ５(大甲)
+  "O5b-": 888,     // ８(大甲)
+  "O6c":  0,       // ２(大甲)(未使用)
+  "O6d":  0,       // ３(大甲)(未使用)
+  "O6e-": 0,       // ４(大甲)(未使用)
+  "O6f":  0,       // ５(大甲)(未使用)
   "O6g":  0,       // (未使用)
 };
 
@@ -76,6 +73,7 @@ function playMusic(sheet) {
     // 再生中は何もせずに終了
     return;
   }
+  const tempo = document.getElementById('tempo').value
   context = new AudioContext();
   const gainNode = context.createGain();
   gainNode.gain.value = volume;

--- a/app/models/concerns/scale_info.rb
+++ b/app/models/concerns/scale_info.rb
@@ -8,19 +8,19 @@ module ScaleInfo
           # 都節音階(レベル1)
           last: [3],
           pitch: ["O3b-", "O4d", "O4e-", "O4g", "O4a"],
-          probability: 60,
+          probability: 45,
         },
         {
           # 民謡音階(レベル1)
           last: [1, 2],
           pitch: ["O3b-", "O4c", "O4e-", "O4f", "O4g"],
-          probability: 15,
+          probability: 20,
         },
         {
           # 律音階(レベル1)
           last: [2],
           pitch: ["O4c", "O4d", "O4f", "O4g", "O4a"],
-          probability: 15,
+          probability: 25,
         },
         {
           # 琉球音階(レベル1)
@@ -34,7 +34,7 @@ module ScaleInfo
           # 都節音階(レベル2)
           last: [3, 8],
           pitch: ["O3b-", "O4d", "O4e-", "O4g", "O4a", "O4b-", "O5d", "O5e-", "O5g", "O5a","O5b-"],
-          probability: 60,
+          probability: 45,
         },
         {
           # 民謡音階(レベル2)
@@ -46,13 +46,13 @@ module ScaleInfo
           # 律音階(レベル2-1)
           last: [2, 7],
           pitch: ["O4c", "O4d", "O4f", "O4g", "O4a", "O5c", "O5d", "O5f", "O5g", "O5a"],
-          probability: 7,
+          probability: 15,
         },
         {
           # 律音階(レベル2-2)
           last: [0, 5],
           pitch: ["O3b-", "O4c", "O4d", "O4f", "O4g", "O4b-", "O5c", "O5d", "O5f", "O5g","O5b-"],
-          probability: 8,
+          probability: 15,
         },
         {
           # 琉球音階(レベル2)
@@ -66,13 +66,13 @@ module ScaleInfo
           # 都節音階(レベル3)
           last: [0, 5],
           pitch: ["O4c", "O4d", "O4e-", "O4g", "O4a-", "O5c", "O5d", "O5e-", "O5g", "O5a-"],
-          probability: 60,
+          probability: 45,
         },
         {
           # 民謡音階(レベル3)
           last: [3, 4, 8, 9],
           pitch: ["O3b-", "O4c", "O4e-", "O4f", "O4a-", "O4b-", "O5c", "O5e-", "O5f", "O5a-", "O5b-"],
-          probability: 30,
+          probability: 45,
         },
         {
           # 琉球音階(レベル3)
@@ -86,19 +86,39 @@ module ScaleInfo
           # 都節音階(レベル4)
           last: [2, 7],
           pitch: ["O4c", "O4d-", "O4f", "O4g", "O4a-", "O5c", "O5d-", "O5f", "O5g", "O5a-"],
-          probability: 60,
+          probability: 45,
         },
         {
           # 民謡音階(レベル4)
           last: [0, 1, 5, 6],
           pitch: ["O3b-", "O4d-", "O4e-", "O4f", "O4a-", "O4b-", "O5d-", "O5e-", "O5f", "O5a-", "O5b-"],
-          probability: 30,
+          probability: 45,
         },
         {
           # 琉球音階(レベル4)
           last: [4, 9],
           pitch: ["O4c", "O4d-", "O4e-", "O4g", "O4a-", "O5c", "O5d-", "O5e-", "O5g", "O5a-"],
           probability: 10,
+        },
+      ],
+      [
+        {
+          # 都節音階(レベル5)
+          last: [2, 7],
+          pitch: ["O3b-", "O3b", "O4e-", "O4f", "O4g-", "O4b-", "O4b", "O5e-", "O5f", "O5g-", "O5b-"],
+          probability: 35,
+        },
+        {
+          # ヨナ抜き短音階(レベル5)
+          last: [0, 5],
+          pitch: ["O3b-", "O4c", "O4d-", "O4f", "O4g-", "O4b-", "O5c", "O5d-", "O5f", "O5g-", "O5b-"],
+          probability: 30,
+        },
+        {
+          # 岩戸音階(レベル5)
+          last: [4, 9],
+          pitch: ["O3b-", "O3b", "O4e-", "O4e", "O4a-", "O4b-", "O4b", "O5e-", "O5e", "O5a-", "O5b-"],
+          probability: 35,
         },
       ],
     ]

--- a/app/models/sheet.rb
+++ b/app/models/sheet.rb
@@ -20,8 +20,7 @@ class Sheet < ApplicationRecord
   end
 
   def self.types_of_selectable_levels
-    # {'レベル1': 1, 'レベル2': 2, 'レベル3': 3, 'レベル4': 4, 'レベル5': 5}
-    {'レベル1': 1, 'レベル2': 2, 'レベル3': 3, 'レベル4': 4}
+    {'レベル1': 1, 'レベル2': 2, 'レベル3': 3, 'レベル4': 4, 'レベル5': 5}
   end
 
   def get_length(mml)

--- a/app/views/shared/_common.html.erb
+++ b/app/views/shared/_common.html.erb
@@ -7,7 +7,8 @@
           <%= form.submit t('defaults.make_music'), class: 'btn btn-primary btn-lg' %>
         </li>
         <li class="nav-item">
-          <%= form.select :level, options_for_select(@level, selected: Sheet::DEFAULT_LEVEL), {}, { class: 'form-control' } %>
+          <% level = @sheet ? @sheet.level : Sheet::DEFAULT_LEVEL %>
+          <%= form.select :level, options_for_select(@level, selected: level), {}, { class: 'form-control' } %>
         </li>
       <% end %>
     </ul>

--- a/app/views/sheets/_sheet.html.erb
+++ b/app/views/sheets/_sheet.html.erb
@@ -42,3 +42,6 @@
     </tbody>
   </table>
 </div>
+
+<label for="tempo" class="form-label"><%= t('defaults.tempo') %></label>
+<input type="range" class="form-range" min="20" max="200" value="80" id="tempo">

--- a/app/views/sheets/index.html.erb
+++ b/app/views/sheets/index.html.erb
@@ -1,11 +1,27 @@
 <div class="container">
-    <div class="fs-5 shadow p-3 mb-5 bg-body rounded">
-      <p>「曲を作成する」を押すと、指定レベルの練習曲を自動作成します。</p>
+    <div class="shadow p-3 mb-5 bg-body rounded">
+      <p class="fs-5">「曲を作成する」を押すと、指定レベルの練習曲を自動作成します。</p>
       <ul class="fs-6">
         <li>レベル1：呂音（低音域）のみ</li>
         <li>レベル2：呂音（低音域）と甲音（高音域）</li>
         <li>レベル3：メリ音（半音）「七×」「７×」</li>
         <li>レベル4：メリ音（半音）「三×」「３×」「七×」「７×」</li>
+        <li>レベル5：メリ音（半音）「二×」「２×」「三×」「３×」「五×」「５×」「六×」「６×」「七×」「７×」</li>
+      </ul>
+    </div>
+    <div class="shadow p-3 mb-5 bg-body rounded">
+      <p class="fs-5">作成した練習曲は、六本調子のドレミ調の篠笛とほぼ同じ音程で再生できます。</p>
+      <ul class="fs-6">
+        <li>ソルフェジオ周波数を含む音を使用しています（甲音２の音を528Hzに調整）</li>
+        <li>テンポを変更できます（♩=20〜200）（再生中は変更できません）</li>
+      </ul>
+    </div>
+    <div class="shadow p-3 mb-5 bg-body rounded">
+      <p class="fs-5">ユーザー登録するとできること</p>
+      <ul class="fs-6">
+        <li>作成した練習曲の保存（気になる曲が出来たら是非保存していただきたいです）</li>
+        <li>練習曲に対するコメントの投稿や、音声/動画をアップロードできる機能を、今後追加予定です。</li>
+      </ul>
     </div>
     <table class="table">
       <thead class="table-light">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -15,6 +15,7 @@ ja:
     password_reset: 'パスワードリセット'
     unspecified: '指定なし'
     level: 'レベル'
+    tempo: 'テンポ'
     make_music: '曲を作成する'
     message:
       require_login: 'ログインしてください'


### PR DESCRIPTION
## 概要

練習曲作成処理の見直し #25
- レベル5の練習曲を作成できるようにする
- 連続して同じレベルを指定できるようにする
- 音階の選択の確率を見直し
- 再生の音に関する説明を記載
- テンポを渡して再生速度を変える