### PR TITLE
Fix: パスワードリセットメールのhost変更

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,3 @@
 default_url_options:
   protocol: 'https'
-  host: 'shinobue-etude.fly.dev'
+  host: 'www.shinobue-dx.com'


### PR DESCRIPTION
## 概要

デプロイ先をFly.ioからHerokuに移行する #55
それにあたり、ホスト名をFly.ioにしていた箇所を修正する。
（元々Fly.ioのホスト名を指定するのではなく、独自に取得したドメインで指定すべきだった）

## コメント

Fly.ioに関するファイルについては、とりあえずそのままとしました。